### PR TITLE
Enable choice of library version for the mujs shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,13 +90,15 @@ $(OUT)/libmujs.$(SO_EXT): one.c $(HDRS)
 	@ mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -fPIC -shared $(LDFLAGS) -o $@ $< -lm
 
-$(OUT)/mujs: $(OUT)/libmujs.o $(OUT)/main.o
-	@ mkdir -p $(@D)
-	$(CC) $(LDFLAGS) -o $@ $^ $(LIBREADLINE) -lm
+libmujs ?= libmujs.a
 
-$(OUT)/mujs-pp: $(OUT)/libmujs.o $(OUT)/pp.o
+$(OUT)/mujs: $(OUT)/main.o $(OUT)/$(libmujs)
 	@ mkdir -p $(@D)
-	$(CC) $(LDFLAGS) -o $@ $^ -lm
+	$(CC) $(LDFLAGS) -o $@ $< -L$(OUT) -l:$(libmujs) $(LIBREADLINE) -lm
+
+$(OUT)/mujs-pp: $(OUT)/pp.o $(OUT)/$(libmujs)
+	@ mkdir -p $(@D)
+	$(CC) $(LDFLAGS) -o $@ $< -L$(OUT) -l:$(libmujs) -lm
 
 .PHONY: $(OUT)/mujs.pc
 $(OUT)/mujs.pc:

--- a/Makefile
+++ b/Makefile
@@ -75,27 +75,27 @@ one.c: $(SRCS)
 jsdump.c: astnames.h opnames.h
 
 $(OUT)/%.o: %.c $(HDRS)
-	@ mkdir -p $(dir $@)
+	@ mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -c $<
 
 $(OUT)/libmujs.o: one.c $(HDRS)
-	@ mkdir -p $(dir $@)
+	@ mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -o $@ -c $<
 
 $(OUT)/libmujs.a: $(OUT)/libmujs.o
-	@ mkdir -p $(dir $@)
+	@ mkdir -p $(@D)
 	$(AR) cr $@ $^
 
 $(OUT)/libmujs.$(SO_EXT): one.c $(HDRS)
-	@ mkdir -p $(dir $@)
+	@ mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -fPIC -shared $(LDFLAGS) -o $@ $< -lm
 
 $(OUT)/mujs: $(OUT)/libmujs.o $(OUT)/main.o
-	@ mkdir -p $(dir $@)
+	@ mkdir -p $(@D)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBREADLINE) -lm
 
 $(OUT)/mujs-pp: $(OUT)/libmujs.o $(OUT)/pp.o
-	@ mkdir -p $(dir $@)
+	@ mkdir -p $(@D)
 	$(CC) $(LDFLAGS) -o $@ $^ -lm
 
 .PHONY: $(OUT)/mujs.pc


### PR DESCRIPTION
Default behavior is unchanged, but enables to chose the dynamic version by passing "libmujs=libmujs.so" to make.